### PR TITLE
chore: add a list of all existing recommended modules

### DIFF
--- a/modules-list.json
+++ b/modules-list.json
@@ -1,0 +1,70 @@
+[
+  {
+    "name": "cldr-localenames-full",
+    "npmlink": "https://npmjs.com/package/cldr-localenames-full"
+  },
+  {
+    "name": "eslint",
+    "npmlink": "https://www.npmjs.com/package/eslint"
+  },
+  {
+    "name": "express",
+    "npmlink": "https://www.npmjs.com/package/express"
+  },
+  {
+    "name": "express-prom-bundle",
+    "npmlink": "https://www.npmjs.com/package/express-prom-bundle"
+  },
+  {
+    "name": "helmet",
+    "npmlink": "https://www.npmjs.com/package/helmet"
+  },
+  {
+    "name": "ibmcloud-appid",
+    "npmlink": "https://www.npmjs.com/package/ibmcloud-appid"
+  },
+  {
+    "name": "i18next",
+    "npmlink": "https://www.npmjs.com/package/i18next"
+  },
+  {
+    "name": "i18next-icu",
+    "npmlink": "https://www.npmjs.com/package/i18next-icu"
+  },
+  {
+    "name": "i18next-express-middleware",
+    "npmlink": "https://www.npmjs.com/package/i18next-express-middleware"
+  },
+  {
+    "name": "i18next-node-fs-backend",
+    "npmlink": "https://www.npmjs.com/package/i18next-node-fs-backend"
+  },
+  {
+    "name": "ioredis",
+    "npmlink": "https://www.npmjs.com/package/ioredis"
+  },
+  {
+    "name": "node-rdkafka",
+    "npmlink": "https://www.npmjs.com/package/node-rdkafka"
+  },
+  {
+    "name": "opossum",
+    "npmlink": "https://www.npmjs.com/package/opossum"
+  },
+  {
+    "name": "passport",
+    "npmlink": "https://www.npmjs.com/package/passport"
+  },
+  {
+    "name": "pino",
+    "npmlink": "https://www.npmjs.com/package/pino"
+  },
+  {
+    "name": "prom-client",
+    "npmlink": "https://www.npmjs.com/package/prom-client"
+  },
+  {
+    "name": "rhea",
+    "npmlink": "https://www.npmjs.com/package/rhea"
+  }
+]


### PR DESCRIPTION
This adds a list of all the recommended modules that are in the current docs.  I think i got all of them

I think this will help with #22 .  If there are other fields we think are helpful,  we can add them.  As of now,  it is just `name` and `npmlink`,  that `npmlink` field might be a little redundant though.


cc @mhdawson  