### PR TITLE
doc: add module diligence section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ with only a subset of sections having recommendations):
 
 ## Module Diligence
 
-As a minium, any modules recommended as part of this reference architeucture should meet the following criteria:
+As a minimum, any modules recommended as part of this reference architecture should meet the following criteria:
 
 * The module is not deprecated.
 * The module has an appropriate license.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ with only a subset of sections having recommendations):
   * Load-balancing
   * [Failure Handling](./docs/operations/failurehandling.md)
 
+## Module Diligence
+
+As a minium, any modules recommended as part of this reference architeucture should meet the following criteria:
+
+* The module is not deprecated.
+* The module has an appropriate license.
+  * _Can we define what we consider an 'appropriate' license is in this context?_
+* The module runs on LTS versions of Node.js.
+* The module has appropriate testing.
+* The module is still receiving updates and producing.releases to fix known security vulnerabilities.
+
 ## Contributing
 
 To Contribute to this project, please see the [Contributing Guide](./CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -89,10 +89,13 @@ As a minium, any modules recommended as part of this reference architeucture sho
 
 * The module is not deprecated.
 * The module has an appropriate license.
-  * _Can we define what we consider an 'appropriate' license is in this context?_
+  * Generally leaning towards permissive licenses such as MIT - others should be reviewed on case by case basis.
 * The module runs on LTS versions of Node.js.
 * The module has appropriate testing.
-* The module is still receiving updates and producing.releases to fix known security vulnerabilities.
+* The module is appropriately maintained:
+  * Regular releases (where appropriate).
+  * Critical bugs reports are acknowledged and addressed.
+  * Reported security vulnerabilities are patched and released.
 
 ## Contributing
 


### PR DESCRIPTION
Opening a Draft PR just to start collating feedback on the minimum diligence we should be doing on each of the recommended modules. I've added just some personal ideas just to start. Some of them may seem obvious, but I thought it would be good to explicitly call them out in case it is something we can easily automate as a check.

I propose we spend 10 minutes discussing/defining/expanding this criteria as a group in our next meeting. Following that discussion/agreement, we can explore automating some of these checks (I know there are existing tools for checking licenses, etc.).

Also, I just added this to the README for now, but I am not sure that is the best place for it to live.