### PR TITLE
chore: Add top level npm section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ with only a subset of sections having recommendations):
     - [Code Consistency](./docs/development/code-consistency.md)
     - Testing
   - References to CI/CD
-  - Npm Mirroring
+  - Npm
+    - Npm Proxy / Internal Registries
+    - Npm Publishing
+    - Package Development
   - Secure Development Process
 
 - Operations


### PR DESCRIPTION
fixes #51

I haven't gone back to watch the most recent meeting video, but i think this is what we were talking about with adding a npm section to the development section
