### PR TITLE
Fixing Typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 Contributions are welcome through pull requests, however, the reference architecture
-is intended to reflect the opinion of Red Hat and IBM based on the key tenants
+is intended to reflect the opinion of Red Hat and IBM based on the key tenets
 outlined in the README.md. Therefore only PR's which are aligned with that
 opinion will be accepted.
 


### PR DESCRIPTION
I thought it was `tenet` and not `tenent`, but dictionary says they mean the same, however `tenent` is now obsolete.