### PR TITLE
chore: separate npcheck runs to their own workflow

### DIFF
--- a/.github/workflows/npcheck.yml
+++ b/.github/workflows/npcheck.yml
@@ -3,6 +3,7 @@
 # - Regularly (once a week).
 # - When `npcheck.json` or this workflow file is changed.
 
+
 name: Due Dilligence
 
 on:

--- a/.github/workflows/npcheck.yml
+++ b/.github/workflows/npcheck.yml
@@ -3,7 +3,6 @@
 # - Regularly (once a week).
 # - When `npcheck.json` or this workflow file is changed.
 
-
 name: Due Dilligence
 
 on:

--- a/.github/workflows/npcheck.yml
+++ b/.github/workflows/npcheck.yml
@@ -1,0 +1,35 @@
+# This workflow will run the due dilligence checks provided by `npcheck`:
+# - On demand.
+# - Regularly (once a week).
+# - When `npcheck.json` or this workflow file is changed.
+
+name: Due Dilligence
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0"
+  push:
+    branches: [ main ]
+    paths:
+      - ".github/workflows/npcheck.yml"
+      - "npcheck.json"
+  pull_request:
+    branches: [ main ]
+    paths:
+      - ".github/workflows/npcheck.yml"
+      - "npcheck.json"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [ lts/* ]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npx npcheck --github-token ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -31,4 +31,3 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install && npm run lint
-    - run: npx npcheck --github-token ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Run `npcheck` in its own workflow rather than part of the documentation
StyleCheck workflow.