### PR TITLE
chore: add blog links to the sections that have blogs written for them

### DIFF
--- a/docs/development/building-good-containers.md
+++ b/docs/development/building-good-containers.md
@@ -226,3 +226,8 @@ system you are running on, there may be other options which
 provide advantages and are worth considering. You can
 read more about some of these in
 [Podman and Buildah for Docker users](https://developers.redhat.com/blog/2019/02/21/podman-and-buildah-for-docker-users#what_is_buildah_and_why_would_i_use_it_-h2).
+
+
+## Further Reading
+
+[Introduction to the Node.js reference architecture: Building Good Containers](https://developers.redhat.com/articles/2021/08/26/introduction-nodejs-reference-architecture-part-5-building-good-containers)

--- a/docs/development/code-consistency.md
+++ b/docs/development/code-consistency.md
@@ -106,3 +106,7 @@ if not all teams.
   ```
 
 - Always ensure CI/CD is running linting regardless of hooks.
+
+## Further Reading
+
+[Introduction to the Node.js reference architecture: Code Consistency](https://developers.redhat.com/articles/2021/05/17/introduction-nodejs-reference-architecture-part-3-code-consistency)

--- a/docs/development/code-coverage.md
+++ b/docs/development/code-coverage.md
@@ -55,3 +55,8 @@ A common output format is the lcov format, which the recommeneded modules can pr
 
 [jest]: https://www.npmjs.com/package/jest
 [nyc]: https://www.npmjs.com/package/nyc
+
+
+## Further Reading
+
+[Introduction to the Node.js reference architecture: Choosing Web Frameworks](https://developers.redhat.com/articles/2022/03/02/introduction-nodejs-reference-architecture-part-7-code-coverage)

--- a/docs/functional-components/graphql.md
+++ b/docs/functional-components/graphql.md
@@ -130,3 +130,7 @@ https://github.com/valu-digital/graphql-codegen-persisted-query-ids
 For dynamic persisted queries we recomend
 
 2. [Apollo APQs](https://www.apollographql.com/docs/apollo-server/performance/apq/) which needs [Apollo server](https://www.apollographql.com/docs/apollo-server/)
+
+## Further Reading
+
+[Introduction to the Node.js reference architecture: GraphQL](https://developers.redhat.com/articles/2021/06/22/introduction-nodejs-reference-architecture-part-4-graphql-nodejs)

--- a/docs/functional-components/webframework.md
+++ b/docs/functional-components/webframework.md
@@ -52,4 +52,4 @@ When deploying Express we have the following additional recommendations:
 
 ## Further Reading
 
-[Introduction to the Node.js reference architecture: Choosing Web Frameworks](https://developers.redhat.com/articles/2021/12/03/introduction-nodejs-reference-architecture-part-6-choosing-web-frameworks#)
+[Introduction to the Node.js reference architecture: Choosing Web Frameworks](https://developers.redhat.com/articles/2021/12/03/introduction-nodejs-reference-architecture-part-6-choosing-web-frameworks)

--- a/docs/functional-components/webframework.md
+++ b/docs/functional-components/webframework.md
@@ -48,3 +48,8 @@ When deploying Express we have the following additional recommendations:
 - Leverage [CLI](https://nodejs.org/api/cli.html#cli_max_http_header_size_size) or [NODE](https://nodejs.org/api/cli.html#cli_node_options_options) options to increase HTTP headers size. There may be circumstances when cookies pollute header size beyond the 8KB default limit. For such cases, adding `--max-http-header-size=32768` to command line arguments when running the Node.js script will increase the header size. Alternative method is to leverage NODE_OPTIONS environment variable: `NODE_OPTIONS='--max-http-header-size=32768'`
 
   - When changing the max header size, take note of additional upstream clients. As an example, ingresses such as Nginx or even a CDN such as Akamai may need config changes to support the increased header size.
+
+
+## Further Reading
+
+[Introduction to the Node.js reference architecture: Choosing Web Frameworks](https://developers.redhat.com/articles/2021/12/03/introduction-nodejs-reference-architecture-part-6-choosing-web-frameworks#)

--- a/docs/operations/logging.md
+++ b/docs/operations/logging.md
@@ -53,3 +53,7 @@ redacted (like values read from a secret-storage like Vault), one can implement
 redacting logic inside a Pino
 [logMethod](https://getpino.io/#/docs/api?id=logmethod) to filter the message
 string and objects.
+
+## Further Reading
+
+[Introduction to the Node.js reference architecture: Logging](https://developer.ibm.com/blogs/nodejs-reference-architectire-pino-for-logging/)

--- a/docs/operations/logging.md
+++ b/docs/operations/logging.md
@@ -56,4 +56,4 @@ string and objects.
 
 ## Further Reading
 
-[Introduction to the Node.js reference architecture: Logging](https://developer.ibm.com/blogs/nodejs-reference-architectire-pino-for-logging/)
+[Introduction to the Node.js reference architecture: Logging](https://developer.ibm.com/blogs/nodejs-reference-architectire-pino-for-logging)


### PR DESCRIPTION
fixes #105

This adds a "Further Reading" section with a link to the relevant blog post to the sections that have blogs written for them