### PR TITLE
Add modules to the npcheck CITGM skip field

### DIFF
--- a/npcheck.json
+++ b/npcheck.json
@@ -253,6 +253,7 @@
     "note-1" : "ibmcloud-appid, @ibm-cloud/cloudant, opossum, ibm_db are Red Hat/IBM modules that would need broader usage before being considered for CITGM",
     "note-2" : "cldr-localenames-full does not have tests as it is a data delivery module and therefore does not beong in CITGM",
     "note-3" : "eslint and mocha look to be permanently skipped in CIGTM due to needing headless chrome to run tests",
+    "note-4" : "node-rdkafka, rhea, odbc, @openapitools/openapi-generator-cli, openapi-backend, @stoplight/prism-http, express-openapi-validator, swagger-editor, openapi-editor have low download numbers and will be skipped in CITGM",
     "skip": [
       "ibmcloud-appid",
       "@ibm-cloud/cloudant",
@@ -260,7 +261,16 @@
       "ibm_db",
       "cldr-localenames-full",
       "eslint",
-      "mocha"
+      "mocha",
+      "node-rdkafka",
+      "rhea",
+      "odbc",
+      "@openapitools/openapi-generator-cli",
+      "openapi-backend",
+      "@stoplight/prism-http",
+      "express-openapi-validator",
+      "swagger-editor",
+      "openapi-editor"
     ]
   },
   "audit": {

--- a/npcheck.json
+++ b/npcheck.json
@@ -252,12 +252,15 @@
   "citgm": {
     "note-1" : "ibmcloud-appid, @ibm-cloud/cloudant, opossum, ibm_db are Red Hat/IBM modules that would need broader usage before being considered for CITGM",
     "note-2" : "cldr-localenames-full does not have tests as it is a data delivery module and therefore does not beong in CITGM",
+    "note-3" : "eslint and mocha look to be permanently skipped in CIGTM due to needing headless chrome to run tests",
     "skip": [
       "ibmcloud-appid",
       "@ibm-cloud/cloudant",
       "opossum",
       "ibm_db",
-      "cldr-localenames-full"
+      "cldr-localenames-full",
+      "eslint",
+      "mocha"
     ]
   },
   "audit": {

--- a/npcheck.json
+++ b/npcheck.json
@@ -254,6 +254,7 @@
     "note-2" : "cldr-localenames-full does not have tests as it is a data delivery module and therefore does not beong in CITGM",
     "note-3" : "eslint and mocha look to be permanently skipped in CIGTM due to needing headless chrome to run tests",
     "note-4" : "node-rdkafka, rhea, odbc, @openapitools/openapi-generator-cli, openapi-backend, @stoplight/prism-http, express-openapi-validator, swagger-editor, openapi-editor have low download numbers and will be skipped in CITGM",
+    "note-5" : "kafkajs, @elastic/elasticsearch, helmet, passport propose additions to CITGM in the future",
     "skip": [
       "ibmcloud-appid",
       "@ibm-cloud/cloudant",
@@ -270,7 +271,11 @@
       "@stoplight/prism-http",
       "express-openapi-validator",
       "swagger-editor",
-      "openapi-editor"
+      "openapi-editor",
+      "kafkajs",
+      "@elastic/elasticsearch",
+      "helmet",
+      "passport"
     ]
   },
   "audit": {

--- a/npcheck.json
+++ b/npcheck.json
@@ -252,7 +252,13 @@
   "citgm": {
     "note-1" : "ibmcloud-appid, @ibm-cloud/cloudant, opossum, ibm_db are Red Hat/IBM modules that would need broader usage before being considered for CITGM",
     "note-2" : "cldr-localenames-full does not have tests as it is a data delivery module and therefore does not beong in CITGM",
-    "skip": ["ibmcloud-appid", "@ibm-cloud/cloudant", "opossum", "ibm_db", "cldr-localenames-full"]
+    "skip": [
+      "ibmcloud-appid",
+      "@ibm-cloud/cloudant",
+      "opossum",
+      "ibm_db",
+      "cldr-localenames-full"
+    ]
   },
   "audit": {
     "allow": {

--- a/npcheck.json
+++ b/npcheck.json
@@ -255,6 +255,7 @@
     "note-3" : "eslint and mocha look to be permanently skipped in CIGTM due to needing headless chrome to run tests",
     "note-4" : "node-rdkafka, rhea, odbc, @openapitools/openapi-generator-cli, openapi-backend, @stoplight/prism-http, express-openapi-validator, swagger-editor, openapi-editor have low download numbers and will be skipped in CITGM",
     "note-5" : "kafkajs, @elastic/elasticsearch, helmet, passport propose additions to CITGM in the future",
+    "note-6" : "nano, express-prom-bundle, i18next-icu, i18next-http-middleware, i18next-fs-backend review in the future to see if they make sense to add to CITGM",
     "skip": [
       "ibmcloud-appid",
       "@ibm-cloud/cloudant",
@@ -275,7 +276,12 @@
       "kafkajs",
       "@elastic/elasticsearch",
       "helmet",
-      "passport"
+      "passport",
+      "nano",
+      "express-prom-bundle",
+      "i18next-icu",
+      "i18next-http-middleware",
+      "i18next-fs-backend"
     ]
   },
   "audit": {


### PR DESCRIPTION
This PR adds a bunch of the modules that are not tested by CITGM to the skip CITGM section with notes on why they are being moved their.

There are some modules that we have marked(in our internal meetings) for proposing to add to CITGM,  if those modules make it in,  then they will disappear from the "not in CITGM" list over time.