### PR TITLE
chore: move node_rdkafka to the top of the list in npcheck.json

### DIFF
--- a/npcheck.json
+++ b/npcheck.json
@@ -116,16 +116,6 @@
       ]
     },
     {
-      "name": "node-rdkafka",
-      "npmlink": "https://www.npmjs.com/package/node-rdkafka",
-      "reviewlevel": "Active Watch",
-      "activitycurrent": "None",
-      "activitytarget": "Tested and Verified",
-      "section": [
-        "Message Queuing"
-      ]
-    },
-    {
       "name": "opossum",
       "npmlink": "https://www.npmjs.com/package/opossum",
       "reviewlevel": "Yearly Watch",

--- a/npcheck.json
+++ b/npcheck.json
@@ -1,6 +1,16 @@
 {
   "modules": [
     {
+      "name": "node-rdkafka",
+      "npmlink": "https://www.npmjs.com/package/node-rdkafka",
+      "reviewlevel": "Active Watch",
+      "activitycurrent": "None",
+      "activitytarget": "Tested and Verified",
+      "section": [
+        "Message Queuing"
+      ]
+    },
+    {
       "name": "cldr-localenames-full",
       "npmLink": "https://npmjs.com/package/cldr-localenames-full",
       "reviewlevel": "Yearly Watch",


### PR DESCRIPTION
The npcheck ci has been failing when consistently when doing checks on the node_rdkafka library.  For some reason, when moving that entry to the top of the list,  it works.


